### PR TITLE
Fix notification not displaying on non-English systems

### DIFF
--- a/Peninsula/Notch/NotchViewModel+Events.swift
+++ b/Peninsula/Notch/NotchViewModel+Events.swift
@@ -45,7 +45,7 @@ extension NotchViewModel {
                         if true {
                             if abstractRect.insetBy(dx: inset, dy: inset).contains(mouseLocation) {
                                 if nm.displayedName != "" {
-                                    nm.open(name: nm.displayedName)
+                                    nm.open(bundleId: nm.displayedName)
                                 } else {
                                     notchOpen(.notification)
                                 }

--- a/Peninsula/Notch/Notification/NotificationContentView.swift
+++ b/Peninsula/Notch/Notification/NotificationContentView.swift
@@ -16,14 +16,14 @@ struct NotificationContentView: View {
     var body: some View {
         HStack(alignment: .top, spacing: nvm.spacing) {
             ForEach(Array(nm.items.keys), id: \.self) { key in
-                AppIcon(name: key, image: nm.items[key]!.icon, vm: nvm)
+                AppIcon(bundleId: key, image: nm.items[key]!.icon, vm: nvm)
             }
         }.animation(nvm.normalAnimation, value: nm.items)
     }
 }
 
 private struct AppIcon: View {
-    let name: String
+    let bundleId: String
     let image: NSImage
     @ObservedObject var nm = NotificationModel.shared
     @StateObject var vm: NotchViewModel
@@ -57,7 +57,7 @@ private struct AppIcon: View {
                 )
                 .overlay(
                     ZStack {
-                        if let badge = nm.items.filter({ $0.value.name == name }).first?.value.badge
+                        if let badge = nm.items.filter({ $0.value.bundleId == bundleId }).first?.value.badge
                         {
                             switch badge {
                             case .count(let count):
@@ -98,10 +98,10 @@ private struct AppIcon: View {
                 }
                 .onTapGesture {
                     if vm.mode == .delete {
-                        nm.unobserve(name: name)
+                        nm.unobserve(bundleId: bundleId)
                     } else {
                         vm.notchClose()
-                        nm.open(name: name)
+                        nm.open(bundleId: bundleId)
                     }
                 }
                 .onChange(of: vm.mode) { newMode in

--- a/Peninsula/Notch/Notification/NotificationMenubarView.swift
+++ b/Peninsula/Notch/Notification/NotificationMenubarView.swift
@@ -31,8 +31,7 @@ struct NotificationMenubarView: View {
                         else {
                             return
                         }
-                        nm.observe(
-                            name: appName, bundleId: appBundle.bundleIdentifier ?? "")
+                        nm.observe(bundleId: appBundle.bundleIdentifier ?? "")
                     } else {
                         vm.isExternal = false
                     }

--- a/Peninsula/Switch/Model/Application.swift
+++ b/Peninsula/Switch/Model/Application.swift
@@ -13,6 +13,7 @@ class Application {
     var isHidden: Bool = false
     var label: String? = nil
     var name: String? = nil
+    var bundleId: String? = nil
     
     static let notifications = [
         kAXApplicationActivatedNotification,
@@ -28,6 +29,7 @@ class Application {
         self.runningApplication = runningApplication
         self.icon = runningApplication.icon
         self.name = runningApplication.localizedName
+        self.bundleId = runningApplication.bundleIdentifier
         self.addObserver()
         manuallyUpdateWindows()
     }


### PR DESCRIPTION
Problems: 
- The AX title name matches the localized name of the NSRunningApp. On English systems, the CFBundleName is identical to the AX title name, but on non-English systems, they differ.

Solutions: 
- Use the bundle ID to retrieve the localized name instead of relying on the CFBundleName directly.